### PR TITLE
Add css for the legal and copyright text color on the login screen

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -52,12 +52,23 @@
   color: #fff; /* color of the text */
   border: 1px solid #fff;
 }
-
 /* style for the hovered state of the button */
 #alternative-logins li a.button:hover, html #body-login input[type="submit"]:hover, html #body-login button[type="submit"]:hover {
 	background-color: #947bea;
 	color: #fff; /* color of the text */
   border: 1px solid #fff;
+}
+
+/* style legal and copyright text */
+/* styling of the info text of the login page on the button. */
+/* the color of the p.info part is also the color of the text above the credential fields (used by ownCloud >= 10.8) */
+/* also the color of error messages will be changed to the provided value */
+#body-login p.info, #body-login .warning, #body-login .update, #body-login .error, #body-login #showAdvanced {
+  color: #fff;
+}
+/* legal and copyright text (Link) */
+#body-login p.info a, #body-login .update a, #body-login form fieldset legend, #body-login #datadirContent label {
+  color: #fff;
 }
 
 /* primary action button, use sparingly */


### PR DESCRIPTION
With this PR CSS for styling of the info text of the login page on the button is added to the `core/css/style.css` file.

You can now change the color of the copyright and legal text by adapting the value of `p.info`.

The color of the `p.info` part is also the color of the text above the credential fields (used by ownCloud >= 10.8).

Example with both values changed to #000:

```
#body-login p.info, #body-login .warning, #body-login .update, #body-login .error, #body-login #showAdvanced {
  color: #000;
}
#body-login p.info a, #body-login .update a, #body-login form fieldset legend, #body-login #datadirContent label {
  color: #000;
}
```

![image](https://user-images.githubusercontent.com/33026403/152319810-f2378dc7-9612-49d1-b5f6-31e66ff6d0ab.png)

Note: Also info, update and warnings will be displayed in the text you choose.

![image](https://user-images.githubusercontent.com/33026403/152320258-e39e8f6c-cd1b-4b32-9b08-5799866cf558.png)

